### PR TITLE
Secure hosting routes and centralize Plesk config

### DIFF
--- a/openapi/leopard-api.v1.yaml
+++ b/openapi/leopard-api.v1.yaml
@@ -28,8 +28,23 @@ paths:
       summary: Elenco hosting (cache Plesk)
       parameters:
         - in: query
-          name: domain
+          name: companyId
+          required: true
           schema: { type: string }
+        - in: query
+          name: q
+          schema: { type: string }
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [attivo, sospeso, in_attivazione, unknown]
+        - in: query
+          name: page
+          schema: { type: integer }
+        - in: query
+          name: pageSize
+          schema: { type: integer }
       responses:
         "200": { description: OK }
   /webspace/hosting/sync:

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -22,5 +22,6 @@ export const env = {
     baseUrl: required('PLESK_BASE_URL', process.env.PLESK_BASE_URL),
     username: required('PLESK_USERNAME', process.env.PLESK_USERNAME),
     password: required('PLESK_PASSWORD', process.env.PLESK_PASSWORD),
+    apiToken: process.env.PLESK_API_TOKEN,
   }
 };

--- a/src/modules/webspace/hosting/controller.ts
+++ b/src/modules/webspace/hosting/controller.ts
@@ -7,7 +7,7 @@ import { listDomainsWithStatus } from "../plesk/client";
  */
 export async function getList(req: Request, res: Response) {
   try {
-    const companyId = String(req.query.companyId || "");
+    const companyId = String((req as any).companyId || "");
     if (!companyId) return res.status(400).json({ error: "companyId is required" });
 
     const q = String(req.query.q || "").trim();
@@ -37,7 +37,7 @@ export async function getList(req: Request, res: Response) {
  */
 export async function syncNow(req: Request, res: Response) {
   try {
-    const companyId = String(req.query.companyId || "");
+    const companyId = String((req as any).companyId || "");
     if (!companyId) return res.status(400).json({ error: "companyId is required" });
 
     const items = await listDomainsWithStatus(10);

--- a/src/modules/webspace/hosting/routes.ts
+++ b/src/modules/webspace/hosting/routes.ts
@@ -1,9 +1,11 @@
 import { Router } from "express";
 import { getList, syncNow, getOne } from "./controller";
+import { auth } from "../../../middlewares/auth";
+import { requireCompany } from "../../../middlewares/tenant";
 
 const r = Router();
-r.get("/webspace/hosting", getList);
-r.post("/webspace/hosting/sync", syncNow);
-r.get("/webspace/hosting/:id", getOne);
+r.get("/", auth, requireCompany, getList);
+r.post("/sync", auth, requireCompany, syncNow);
+r.get("/:id", auth, requireCompany, getOne);
 
 export default r;

--- a/src/modules/webspace/hosting/service.ts
+++ b/src/modules/webspace/hosting/service.ts
@@ -3,7 +3,7 @@ import WebspaceHosting from './model';
 export async function upsertHosting(items: any[], companyId: string) {
   const ops = items.map(it => ({
     updateOne: {
-      filter: { pleskId: String(it.id) },
+      filter: { companyId, pleskId: String(it.id) },
       update: {
         $set: {
           pleskId: String(it.id),


### PR DESCRIPTION
## Summary
- fix webspace hosting router prefixes and add auth + company middlewares
- read companyId from request context throughout hosting controllers and services
- centralize Plesk configuration and update OpenAPI docs

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a84e80eb4832d81862a4079c0f01a